### PR TITLE
Automate building and deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,3 +1,20 @@
+# This workflow builds and deploys the marian-nmt website.
+#
+# It automates:
+#   - generation of CLI version/help markdown
+#   - generation of API documentation
+#   - building of Jekyll website
+#
+# It uses a submodule to marian-dev to facilitate this.
+# The pinned commit determines the API/CLI output.
+#
+# On push events, HTML output from the Sphinx API is added to the Jekyll HTML
+# output and published in the deploy branch
+# NOTE: The CLI markdown is *committed* to the source via this workflow.
+#
+# On PRs, the commit stages are skipped and the Sphinx and Jekyll output are
+# available as artifacts.
+
 name: Website
 
 on:
@@ -9,11 +26,13 @@ on:
     branches:
       - jekyll
 
+  # Allow manual running of this workflow
+  # ONLY RUN THIS ON THE SOURCE BRANCH
   workflow_dispatch:
 
 # Source and Deploy branch names
 env:
-  source: jekyll
+  source: jekyll  # this should reflect the branch used in 'on'
   deploy: master
 
 
@@ -31,11 +50,13 @@ jobs:
         - name: Determine changes since last event
           id: check
           env:
-            ref: ${{ github.event.before }}
+            ref: ${{ github.event.before }}  # ref to the prior event
           run: |
             if [ -z "${{ env.ref }}" ]; then
+              # Assume changes if no prior event reference
               echo '::set-output name=changed::true';
             else
+              # Check diff since prior event to see any changes to the submodule
               git fetch origin ${{ env.ref }} --depth=1
               git diff --name-only ${{ env.ref }}.. | grep '^marian-dev' && \
                 echo '::set-output name=changed::true' || true
@@ -45,8 +66,6 @@ jobs:
             if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
               echo '::set-output name=changed::true';
             fi
-
-
 
   # Compile Marian to get CLI options
   cli:
@@ -166,7 +185,7 @@ jobs:
       # Create _data file with current marian version and sha
       - name: Generate data file
         env:
-          cli: ${{steps.cli.outputs.download-path}}
+          cli: ${{ steps.cli.outputs.download-path }}
         run: |
           version_full=$(cat ${{ env.cli }}/marian.version)
           version=$(awk '{print substr($1,2)}' <<< ${version_full})
@@ -181,7 +200,7 @@ jobs:
       - name: Generate CLI markdown files
         working-directory: .
         env:
-          cli: ${{steps.cli.outputs.download-path}}
+          cli: ${{ steps.cli.outputs.download-path }}
           doc: 'docs/cmd'
         run: |
           for cmd in marian marian-{decoder,server,scorer,vocab,conv}; do
@@ -227,6 +246,7 @@ jobs:
           path: ./_site
 
   # Generates API docs
+  # Based on marian-dev/.github/workflows/documentation.yml
   api:
     name: Build API documentation
     needs: [check_source]

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -84,7 +84,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update -y && \
-          sudo apt-get install -y libboost-all-dev \
+          sudo apt-get install -y libboost-system-dev \
             libgoogle-perftools-dev libprotobuf-dev protobuf-compiler
 
       - name: Install CUDA

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -304,8 +304,7 @@ jobs:
 
       # Updates API documentation, deleting unknown files in destination
       - name: Add API docs to website
-        run:
-          rsync -avh --checksum --delete api/docs/api/ jekyll/docs/api
+        run: rsync -avh --checksum --delete api/docs/api/ jekyll/docs/api
 
       # Deploy to live branch
       - name: Deploy

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,316 @@
+name: Website
+
+on:
+  push:
+    branches:
+      - jekyll
+
+  pull_request:
+    branches:
+      - jekyll
+
+  workflow_dispatch:
+
+# Source and Deploy branch names
+env:
+  source: jekyll
+  deploy: master
+
+
+jobs:
+  # Check if marian submodule was updated
+  check_source:
+      name: Check for source changes
+      outputs:
+        changed: ${{ steps.check.outputs.changed }}
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout source code
+          uses: actions/checkout@v2
+
+        - name: Determine changes since last event
+          id: check
+          env:
+            ref: ${{ github.event.before }}
+          run: |
+            if [ -z "${{ env.ref }}" ]; then
+              echo '::set-output name=changed::true';
+            else
+              git fetch origin ${{ env.ref }} --depth=1
+              git diff --name-only ${{ env.ref }}.. | grep '^marian-dev' && \
+                echo '::set-output name=changed::true' || true
+            fi
+
+            # Always run on workflow_dispatch
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo '::set-output name=changed::true';
+            fi
+
+
+
+  # Compile Marian to get CLI options
+  cli:
+    name: Build CLI documentation
+    env:
+      gcc: 7
+      cuda: "11.2"
+    defaults:
+      run:
+        working-directory: marian-dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Get marian submodule SHA
+        id: version
+        run: |
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+
+      # Cache output of --version/help to save on recompilation
+      - name: Set up cache for marian output
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            marian-dev/build/marian*.version
+            marian-dev/build/marian*.help
+          key: ${{ runner.os }}-${{ steps.version.outputs.sha }}
+
+      # Only compile if the cache is expired
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update -y && \
+          sudo apt-get install -y libboost-all-dev \
+            libgoogle-perftools-dev libprotobuf-dev protobuf-compiler
+
+      - name: Install CUDA
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: ./scripts/ci/install_cuda_ubuntu.sh ${{ env.cuda }}
+
+      - name: Configure CMake
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir build && cd build
+          CC=/usr/bin/gcc-${{ env.gcc }} \
+          CXX=/usr/bin/g++-${{ env.gcc }} \
+          CUDAHOSTCXX=/usr/bin/g++-${{ env.gcc }} \
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCOMPILE_CPU=ON \
+            -DCOMPILE_CUDA=ON \
+            -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-${{ env.cuda }}/ \
+            -DCOMPILE_SERVER=ON \
+            -DCOMPILE_EXAMPLES=OFF \
+            -DCOMPILE_TESTS=OFF \
+            -DUSE_FBGEMM=ON \
+            -DUSE_SENTENCEPIECE=ON \
+            -DUSE_STATIC_LIBS=OFF
+
+      - name: Compile
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: marian-dev/build
+        run: make -j2
+
+      - name: Output version and help files
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: marian-dev/build
+        run: |
+          for cmd in marian marian-{decoder,server,scorer,vocab,conv}; do
+            ./${cmd} --version > ${cmd}.version 2>&1
+            ./${cmd} --help > ${cmd}.help 2>&1
+          done
+
+      - name: Output SHA file
+        working-directory: marian-dev/build
+        run: echo "${{ steps.version.outputs.sha }}" > marian.sha
+
+      # Artifact contains the output of --version and --help for each command as
+      # well as the submodule sha.
+      - name: Upload CLI output
+        uses: actions/upload-artifact@v2
+        with:
+          name: cli
+          path: |
+            marian-dev/build/marian*.version
+            marian-dev/build/marian*.help
+            marian-dev/build/marian.sha
+
+  # Build website source
+  site:
+    name: Build website
+    needs: [cli]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout website source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # required for mtime
+          ref: ${{ env.source }}
+          submodules: true
+
+      - name: Download CLI files
+        if: needs.cli.result == 'success'
+        uses: actions/download-artifact@v2
+        id: cli
+        with:
+          name: cli
+          path: ~/cli
+
+      # Create _data file with current marian version and sha
+      - name: Generate data file
+        env:
+          cli: ${{steps.cli.outputs.download-path}}
+        run: |
+          version_full=$(cat ${{ env.cli }}/marian.version)
+          version=$(awk '{print substr($1,2)}' <<< ${version_full})
+
+          cat <<EOF > _data/marian.yml
+          version: ${version}
+          version_full: ${version_full}
+          sha: $(cat ${{ env.cli }}/marian.sha)
+          EOF
+
+      # Create CLI markdown output
+      - name: Generate CLI markdown files
+        working-directory: .
+        env:
+          cli: ${{steps.cli.outputs.download-path}}
+          doc: 'docs/cmd'
+        run: |
+          for cmd in marian marian-{decoder,server,scorer,vocab,conv}; do
+            output="${{ env.doc }}/${cmd}.md"
+            sed "s/<COMMAND>/${cmd}/" ${{ env.doc }}/_template.tmp > ${output}
+            echo "Version: " >> ${output}
+            cat ${{ env.cli }}/${cmd}.version >> ${output} 2>&1
+            echo "" >> ${output}
+            cat ${{ env.cli }}/${cmd}.help 2>&1 | bash _scripts/help2markdown.sh | python _scripts/wrap_help.py >> ${output}
+            git add ${output}
+          done
+
+      # Generates the correct date
+      - name: Commit CLI options
+        run: |
+          git config --global user.name '${{ github.actor }}'
+          git config --global user.email '${{ github.actor }}@users.noreply.github.com'
+          git commit -m "Update CLI options: ${{ github.sha	}}" || true
+
+      # Push on commit
+      - name: Push commit
+        if: ${{ github.event_name == 'push' }}
+        run: git push origin
+
+
+      # Setup Ruby and build Jekyll
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - name: Build Jekyll
+        uses: limjh16/jekyll-action-ts@v2
+        with:
+          enable_cache: true
+          custom_opts: '--baseurl /${{ github.event.repository.name }}'  # enable if testing in a fork
+
+      # This artifact contains the HTML output of Jekyll.
+      # index.html at the root of the produced zip file.
+      - name: Upload HTML
+        uses: actions/upload-artifact@v2
+        with:
+          name: jekyll-output
+          path: ./_site
+
+  # Generates API docs
+  api:
+    name: Build API documentation
+    needs: [check_source]
+    if: needs.check_source.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: marian-dev
+    steps:
+      - name: Checkout website source
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Doxygen
+        run: sudo apt-get install -y doxygen
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('marian-dev/doc/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        working-directory: ./marian-dev/doc
+        run: pip install -r requirements.txt
+
+      - name: Build documentation
+        working-directory: ./marian-dev/doc
+        run: make html
+
+      # This artifact contains the HTML output of Sphinx only.
+      # With index.html at the root of the produced zip file.
+      - name: Upload documentation
+        uses: actions/upload-artifact@v2
+        with:
+          name: api-docs-output
+          path: ./marian-dev/doc/build/html
+
+  # Deploy to branch (on push events only)
+  deploy:
+    name: Deploy to live branch
+    needs: [site, api]
+    if: ${{ !failure() && github.event_name == 'push' }}  # skipped needs are fine, but failures are not
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Jekyll
+        uses: actions/download-artifact@v2
+        with:
+          name: jekyll-output
+          path: jekyll
+
+      # Use New API
+      - name: Download new API documentation
+        if: needs.api.result == 'success'
+        uses: actions/download-artifact@v2
+        with:
+          name: api-docs-output
+          path: api/docs/api  # match fallback api layout to unify rsync command
+
+      # Fallback to use current live API
+      - name: Reuse current API documentation
+        if: needs.api.result == 'skipped'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.deploy }}
+          path: api
+
+      # Updates API documentation, deleting unknown files in destination
+      - name: Add API docs to website
+        run:
+          rsync -avh --checksum --delete api/docs/api/ jekyll/docs/api
+
+      # Deploy to live branch
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./jekyll
+          publish_branch: ${{ env.deploy }}
+          keep_files: false
+          enable_jekyll: false # prevents GitHub running Jekyll

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -103,6 +103,9 @@ jobs:
             -DCOMPILE_CPU=ON \
             -DCOMPILE_CUDA=ON \
             -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-${{ env.cuda }}/ \
+            -DCOMPILE_PASCAL=OFF \
+            -DCOMPILE_VOLTA=OFF \
+            -DCOMPILE_TURING=OFF \
             -DCOMPILE_SERVER=ON \
             -DCOMPILE_EXAMPLES=OFF \
             -DCOMPILE_TESTS=OFF \

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -204,8 +204,7 @@ jobs:
       # Push on commit
       - name: Push commit
         if: ${{ github.event_name == 'push' }}
-        run: git push origin
-
+        run: git push origin ${{ env.source }}
 
       # Setup Ruby and build Jekyll
       - name: Setup Ruby

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "marian-dev"]
+	path = marian-dev
+	url = https://github.com/marian-nmt/marian-dev

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,23 +14,24 @@
 
   <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
   <!-- Global CSS -->
-  <link rel="stylesheet" href="/assets/plugins/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ '/assets/plugins/bootstrap/css/bootstrap.min.css' | relative_url }}">
   <!-- Plugins CSS -->
-  <link rel="stylesheet" href="/assets/plugins/font-awesome/css/font-awesome.min.css">
-  <link rel="stylesheet" href="/assets/css/pygments/{{ site.pygments_css }}.css">
-  <link rel="stylesheet" href="/assets/plugins/lightbox/lightbox.css">
+  <link rel="stylesheet" href="{{ '/assets/plugins/font-awesome/css/font-awesome.min.css' | relative_url }}">
+  {% capture pygment_css %}/assets/css/pygments/{{ site.pygments_css }}.css{% endcapture %}
+  <link rel="stylesheet" href="{{ pygment_css | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/plugins/lightbox/lightbox.css' | relative_url }}">
 
   <!-- Theme CSS -->
-  <link id="theme-style" rel="stylesheet" href="/assets/css/styles.css">
+  <link id="theme-style" rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
   <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
   <![endif]-->
 
-  <link rel="stylesheet" href="/assets/plugins/github-fork-ribbon-css/gh-fork-ribbon.css" />
+  <link rel="stylesheet" href="{{ '/assets/plugins/github-fork-ribbon-css/gh-fork-ribbon.css' | relative_url }}" />
   <!--[if lt IE 9]>
-    <link rel="stylesheet" href="/assets/plugins/github-fork-ribbon-css/gh-fork-ribbon.ie.css" />
+    <link rel="stylesheet" href="{{ '/assets/plugins/github-fork-ribbon-css/gh-fork-ribbon.ie.css' | relative_url }}" />
   <![endif]-->
 
   {% if page.latex == true %}

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -1,12 +1,12 @@
 <!-- Main Javascript -->
 <script type="text/javascript"> localStorage.clear();</script>
 
-<script type="text/javascript" src="/assets/plugins/jquery-1.12.3.min.js"></script>
-<script type="text/javascript" src="/assets/plugins/bootstrap/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="/assets/plugins/jquery-scrollTo/jquery.scrollTo.min.js"></script>
-<script type="text/javascript" src="/assets/plugins/jquery-match-height/jquery.matchHeight-min.js"></script>
+<script type="text/javascript" src="{{ '/assets/plugins/jquery-1.12.3.min.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/assets/plugins/bootstrap/js/bootstrap.min.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/assets/plugins/jquery-scrollTo/jquery.scrollTo.min.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/assets/plugins/jquery-match-height/jquery.matchHeight-min.js' | relative_url }}"></script>
 
 <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
-<script type="text/javascript" src="/assets/js/main.js"></script>
-<script type="text/javascript" src="/assets/js/toc.js"></script>
+<script type="text/javascript" src="{{ '/assets/js/main.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/assets/js/toc.js' | relative_url }}"></script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,10 +40,10 @@
 
     {% include footer.html %}
 
-    <script type="text/javascript" src="/assets/plugins/jquery-1.12.3.min.js"></script>
-    <script type="text/javascript" src="/assets/plugins/bootstrap/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="/assets/plugins/jquery-match-height/jquery.matchHeight-min.js"></script>
-    <script type="text/javascript" src="/assets/js/main.js"></script>
+    <script type="text/javascript" src="{{ '/assets/plugins/jquery-1.12.3.min.js' | relative_url }}"></script>
+    <script type="text/javascript" src="{{ '/assets/plugins/bootstrap/js/bootstrap.min.js' | relative_url }}"></script>
+    <script type="text/javascript" src="{{ '/assets/plugins/jquery-match-height/jquery.matchHeight-min.js' | relative_url }}"></script>
+    <script type="text/javascript" src="{{ '/assets/js/main.js' | relative_url }}"></script>
 
   </body>
 </html>

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -49,6 +49,6 @@
     {% include footer.html %}
     {% include javascript.html %}
 
-    <script type="text/javascript" src="/assets/plugins/lightbox/lightbox.js"></script>
+    <script type="text/javascript" src="{{ '/assets/plugins/lightbox/lightbox.js' | relative_url }}"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds GH actions for building and deploying the marian-nmt website. 

It automates:
  - Generating CLI version/help markdown
  - Generating API documentation
  - Building Jekyll output

It adds a marian-dev as a submodule to facilitate this - the pinned commit determines the API/CLI output.

Note: The CLI markdown output is committed to `jekyll` by this action!

The output of the version/help is cached to avoid repeated compilation. The CI tries to determine if the submodule was updated, and builds the API if necessary -- otherwise, it will recycle the currently live documentation.

On push events, the HTML output of Jekyll is combined with the Sphinx HTML of the API, and published in `master`, which is the live GH-Pages branch.

Related: marian-nmt/marian-dev#814, marian-nmt/marian-dev#815