### PR TITLE
Remove baseurl

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -235,7 +235,7 @@ jobs:
         uses: limjh16/jekyll-action-ts@v2
         with:
           enable_cache: true
-          custom_opts: '--baseurl /${{ github.event.repository.name }}'  # enable if testing in a fork
+          #custom_opts: '--baseurl /${{ github.event.repository.name }}'  # enable if testing in a fork
 
       # This artifact contains the HTML output of Jekyll.
       # index.html at the root of the produced zip file.


### PR DESCRIPTION
Removes baseurl from in live repo.

Baseurl is needed to test deployed jekyll output in repositories without special names. In a specially-named repository, such as `marian-nmt.github.io`, this creates a superfluous extra directory.