### PR TITLE
Improvements to CI

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -232,19 +232,24 @@ jobs:
         with:
           ruby-version: 2.7
 
-      - name: Build Jekyll (Production)
-        id: jekyll
-        if: ${{ github.event_name == 'push' && github.repository == 'marian-nmt/marian-nmt.github.io' }}
-        uses: limjh16/jekyll-action-ts@v2
-        with:
-          enable_cache: true
-
-      - name: Build Jekyll (Dev)
-        if: ${{ steps.jekyll.outcome == 'skipped' }}
+      # Run with baseurl when pushes occur on forks
+      - name: Build Jekyll (Forks)
+        id: jekyll-dev
+        if: ${{ github.event_name == 'push' && github.repository != 'marian-nmt/marian-nmt.github.io' }}
         uses: limjh16/jekyll-action-ts@v2
         with:
           enable_cache: true
           custom_opts: '--baseurl /${{ github.event.repository.name }}'
+
+      # Run without baseurl
+      - name: Build Jekyll
+        id: jekyll
+        if: ${{ steps.jekyll-dev.outcome == 'skipped' }}
+        # if: ${{ github.event_name == 'push' && github.repository == 'marian-nmt/marian-nmt.github.io' }}
+        uses: limjh16/jekyll-action-ts@v2
+        with:
+          enable_cache: true
+
 
       # This artifact contains the HTML output of Jekyll.
       # index.html at the root of the produced zip file.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -181,38 +181,15 @@ jobs:
         id: cli
         with:
           name: cli
-          path: ~/cli
+          path: marian-dev/build
 
       # Create _data file with current marian version and sha
       - name: Generate data file
-        env:
-          cli: ${{ steps.cli.outputs.download-path }}
-        run: |
-          version_full=$(cat ${{ env.cli }}/marian.version)
-          version=$(awk '{print substr($1,2)}' <<< ${version_full})
-
-          cat <<EOF > _data/marian.yml
-          version: ${version}
-          version_full: ${version_full}
-          sha: $(cat ${{ env.cli }}/marian.sha)
-          EOF
+        run: make update-datafile
 
       # Create CLI markdown output
-      - name: Generate CLI markdown files
-        working-directory: .
-        env:
-          cli: ${{ steps.cli.outputs.download-path }}
-          doc: 'docs/cmd'
-        run: |
-          for cmd in marian marian-{decoder,server,scorer,vocab,conv}; do
-            output="${{ env.doc }}/${cmd}.md"
-            sed "s/<COMMAND>/${cmd}/" ${{ env.doc }}/_template.tmp > ${output}
-            echo "Version: " >> ${output}
-            cat ${{ env.cli }}/${cmd}.version >> ${output} 2>&1
-            echo "" >> ${output}
-            cat ${{ env.cli }}/${cmd}.help 2>&1 | bash _scripts/help2markdown.sh | python _scripts/wrap_help.py >> ${output}
-            git add ${output}
-          done
+      - name: Generate CLI
+        run: make update-cmds
 
       # Generates the correct date
       - name: Commit CLI options

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -232,11 +232,19 @@ jobs:
         with:
           ruby-version: 2.7
 
-      - name: Build Jekyll
+      - name: Build Jekyll (Production)
+        id: jekyll
+        if: ${{ github.event_name == 'push' && github.repository == 'marian-nmt/marian-nmt.github.io' }}
         uses: limjh16/jekyll-action-ts@v2
         with:
           enable_cache: true
-          #custom_opts: '--baseurl /${{ github.event.repository.name }}'  # enable if testing in a fork
+
+      - name: Build Jekyll (Dev)
+        if: ${{ steps.jekyll.outcome == 'skipped' }}
+        uses: limjh16/jekyll-action-ts@v2
+        with:
+          enable_cache: true
+          custom_opts: '--baseurl /${{ github.event.repository.name }}'
 
       # This artifact contains the HTML output of Jekyll.
       # index.html at the root of the produced zip file.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -233,7 +233,7 @@ jobs:
           ruby-version: 2.7
 
       # Run with baseurl when pushes occur on forks
-      - name: Build Jekyll (Forks)
+      - name: Build Jekyll (Fork)
         id: jekyll-dev
         if: ${{ github.event_name == 'push' && github.repository != 'marian-nmt/marian-nmt.github.io' }}
         uses: limjh16/jekyll-action-ts@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -104,7 +104,8 @@ jobs:
         run: |
           sudo apt-get update -y && \
           sudo apt-get install -y libboost-system-dev \
-            libgoogle-perftools-dev libprotobuf-dev protobuf-compiler
+            libgoogle-perftools-dev libprotobuf-dev protobuf-compiler \
+            gcc-${{ env.gcc }} g++-${{ env.gcc }}
 
       - name: Install CUDA
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _site
 .jekyll-metadata
 .tweet-cache
 .jekyll-cache
+vendor
 
 # Unix
 *~

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 
 SHELL := /bin/bash
 
-MARIAN   = marian/build
+MARIAN   = marian-dev/build
 COMMANDS = marian marian-decoder marian-server marian-scorer marian-vocab marian-conv
 CMDFILES = $(patsubst %,docs/cmd/%.md,$(COMMANDS))
 
-.PHONY: build clean update-gems update-cmds update-docs install run zip Gamefile.lock
+.PHONY: build clean update-gems update-cmds update-datafile install run zip Gamefile.lock
 
 
 all: run
@@ -27,33 +27,44 @@ zip: marian-nmt-website.tgz
 marian-nmt-website.tgz: build
 	tar zcf $@ _site
 
-# generate pages with command-line options
-update-cmds: $(MARIAN) $(CMDFILES)
+# Generate pages with command-line options
+update-cmds: $(CMDFILES)
+update-datafile: _data/marian.yml
 
-docs/cmd/%.md: docs/cmd/_template.tmp
-	sed "s/<COMMAND>/$*/" $^ > $@
+# Generate Marian version YAML
+_data/marian.yml: $(MARIAN)/marian.version $(MARIAN)/marian.sha
+	_scripts/datafile.sh $^ $@
+
+# CLI Documentation
+$(MARIAN)/%.version:
+	@echo "Ouput Version"
+	$(MARIAN)/$* --version > $@ 2>&1
+
+$(MARIAN)/%.help:
+	@echo "Ouput Help"
+	$(MARIAN)/$* --help > $@ 2>&1
+
+$(MARIAN)/marian.sha:
+	rev=$$(cd $(MARIAN) && echo "$$(git rev-parse HEAD)");\
+	echo $$rev > $@
+
+docs/cmd/%.md: docs/cmd/_template.tmp $(MARIAN)/%.version $(MARIAN)/%.help
+	sed "s/<COMMAND>/$*/" $< > $@
 	echo "Version: " >> $@
-	$(MARIAN)/marian --version >> $@ 2>&1
+	cat $(MARIAN)/$*.version >> $@
 	echo "" >> $@
-	$(MARIAN)/$* -h 2>&1 | bash _scripts/help2markdown.sh | python _scripts/wrap_help.py >> $@
-
-# generate documentation
-update-docs: Doxyfile.marian.in marian
-	sed -i -r "s/PROJECT_NUMBER * = .*/PROJECT_NUMBER = $$(cat marian\/VERSION)/" Doxyfile.marian.in
-	doxygen $<
+	cat $(MARIAN)/$*.help | bash _scripts/help2markdown.sh | python _scripts/wrap_help.py >> $@
 
 
-# download & compile marian
-marian/build: marian
-	mkdir -p marian/build && cd marian/build && cmake .. && make -j8
-marian:
-	git -C $@ pull || git clone https://github.com/marian-nmt/marian-dev.git $@
-	cd marian; git checkout stable; cd ..
+# Compile Marian
+marian-dev/build: marian-dev
+	mkdir -p marian-dev/build && cd marian-dev/build && cmake .. -DCOMPILE_SERVER=ON && make -j8
+
+# Init submodule
+marian-dev:
+	git submodule update --init --recursive
 
 
-# clean
-clean-docs:
-	rm -rf docs/marian
-
-clean: clean-docs
+# Clean
+clean:
 	bundle exec jekyll clean

--- a/README.md
+++ b/README.md
@@ -2,15 +2,48 @@
 
 The website is build with Jekyll - a static site generator.
 The content is created and updated on branch `jekyll`, then the static pages
-are generated with Jekyll and stored in branch `master`. Please **do not update
-files directly in `master`**.
+are generated with Jekyll and stored in the branch `master`.
 
+Please **do not update files directly in `master`**.
 
-We use custom theme, which is not supported by automatic GitHub Pages
-generator. The static files have to be generated locally before deploying.
+## Automated build
+
+The documentation is automatically built and deployed to the [marian-nmt][web]
+website using GitHub Actions.
+
+This covers:
+  - Generation of CLI version/help markdown pages
+  - Generation of API documentation (developer docs)
+  - Building of the Jekyll source
+  - Deployment to website
+
+The CLI and API document content is determined by the pinned version of the
+marian-dev submodule.
+
+The CLI documentation
+
+This pipeline is triggered by pushes on the source branch `jekyll`, and, on
+success, the resulting site is pushed to the GitHub pages branch (`master`).
+
+**Caution!** When new CLI documentation is produced, an automated commit is
+pushed onto the source branch (message: `Update CLI options:`).
+<!--
+This is necessary due to the renderedtimestamp of these files being
+determined from their last-commit date.
+-->
+
+For pull requests against the source branch, the resulting site is available as
+an artifact and should be reviewed before approval.
+
+To review a downloaded jekyll artifact, you can serve it locally with, for
+example:
+```shell
+python3 -m http.server -d /path/to/downloaded/artifact/
+```
 
 
 ## Local build
+For development and test purposes, you can also build the site locally.
 
 If cloning the repository for the first time, download the remote branch:
 
@@ -21,57 +54,46 @@ If cloning the repository for the first time, download the remote branch:
 
 To build the website locally you need to install `ruby` with gem `bundler`.
 
-On Ubuntu 16.04 you can run:
-
-    [sudo] apt-get install ruby-dev
-    [sudo] gem install bundler
+On Ubuntu you can run:
+```shell
+[sudo] apt-get install ruby-dev
+[sudo] gem install bundler
+```
 
 Then, install gem dependencies:
-
-    bundle install
+```shell
+make install
+```
 
 Finally, build the website (it will be generated in `_site` folder) and run a
 local development server:
 
-    make run
-
+```shell
+make run
+```
 The website should be available at `http://127.0.0.1:4000`.
 
 ### Documentation
-
-Documentation has to be updated manually:
-
-    make update-docs
-
-This requires `doxygen` to be installed.
+Documentation in this repository is built from the Jekyll source, with two exceptions:
+ 1. The developer API documentation is built on the [marian-nmt/marian-dev][api_action] repository.
+ 2. The CLI documentation is generated from the `marian` command, and is ran locally as described below.
 
 ### Pages with command-line options
 
-Pages with command-line options for Marian tools have to be updated manually:
+Pages with command-line options for Marian tools have are generated using the provided Makefile:
 
-    rm docs/cmd/marian*.md
-    make -B update-cmds
+```shell
+make -B update-cmds
+make -B update-datafile
+```
+The first command generates the version, and help output. The second generates a
+data file containing the version and commit of Marian used. This compiles
+Marian, so a GPU is required.
 
-This compiles Marian, so GPU is required.
-
-### Logos
+## Logos
 
 Put a logo image into `assets/logos/` and update `_data/logos.yml`.  Use a PNG
 image with transparent background.
-
-
-## Deployment
-
-To update the content of website it should be enough to edit the relevant
-markdown files.
-When all updates have been made and the website can be still generated locally
-*without errors*, you can commit and deploy your changes by running:
-
-    bash -v ./commit-and-deploy.sh
-
-The script commit all changes for you with default commit message, but it is
-always better to commit changes on your own beforehand and set a relevant
-message.
 
 
 ## Tag reference
@@ -84,3 +106,7 @@ message.
 | `[Text](/link){:target="_blank"}` | Opens the linked document in a new window or tab. |
 | `$$ x_{i}^{j} $$` | A LaTeX mathematical formula. |
 | `[Text](/path/to/an/image){:.no-lightbox}` | Disable the automatic image box. |
+
+<!-- Links -->
+[web]: htts://marian-nmt.github.io
+[api_action]: https://github.com/marian-nmt/marian-dev/actions/workflows/documentation.yml

--- a/_scripts/datafile.sh
+++ b/_scripts/datafile.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <VERSION_FILE> <SHA_FILE> <OUTPUT_FILE>"
+    exit 3
+fi
+
+# Inputs
+version_file=$1
+sha_file=$2
+output=$3
+
+# Process
+version_full=$(cat ${version_file})
+version=$(awk '{print substr($1,2)}' <<< ${version_full})
+
+# Output
+cat <<EOF > ${output}
+version: ${version}
+version_full: ${version_full}
+sha: $(cat ${sha_file})
+EOF

--- a/buildtime.md
+++ b/buildtime.md
@@ -3,4 +3,4 @@ layout: home
 permalink: /buildtime/
 ---
 
-Build date: {{ site.time }}
+Build on {{ site.time }} with Marian {{ site.data.marian.version }} ({{ site.data.marian.sha }})

--- a/docs/cmd/index.md
+++ b/docs/cmd/index.md
@@ -9,7 +9,7 @@ icon: fa-file-code-o
 
 Click on the tool name below for a list of command line options.
 
-The [amun](/docs/cmd/amun) tool offering CPU and GPU translation with specific
+The [amun]({% link docs/cmd/amun.md %}) tool offering CPU and GPU translation with specific
 Marian and Nematus models, which used to be a part of Marian, has been moved to
 its separate repository and is available from:
 [https://github.com/marian-nmt/amun](https://github.com/marian-nmt/amun)
@@ -20,16 +20,16 @@ its separate repository and is available from:
 Version:
 {{ site.data.marian.version_full }}
 
-- [marian](/docs/cmd/marian): training NMT models and language models.
-- [marian-decoder](/docs/cmd/marian-decoder): CPU and GPU translation using NMT
+- [marian]({% link docs/cmd/marian.md %}): training NMT models and language models.
+- [marian-decoder]({% link docs/cmd/marian-decoder.md %}): CPU and GPU translation using NMT
   models trained with Marian.
-- [marian-server](/docs/cmd/marian-server): a web-socket server providing
+- [marian-server]({% link docs/cmd/marian-server.md %}): a web-socket server providing
   translation service.
-- [marian-scorer](/docs/cmd/marian-scorer): rescoring parallel text files and
+- [marian-scorer]({% link docs/cmd/marian-scorer.md %}): rescoring parallel text files and
   n-best lists.
-- [marian-vocab](/docs/cmd/marian-vocab): creating a vocabulary from text given
+- [marian-vocab]({% link docs/cmd/marian-vocab.md %}): creating a vocabulary from text given
   on STDIN.
-- [marian-conv](/docs/cmd/marian-conv): converting a model into a binary
+- [marian-conv]({% link docs/cmd/marian-conv.md %}): converting a model into a binary
   format.
 
 
@@ -38,14 +38,14 @@ Version:
 Version:
 v1.7.0 67124f8 2018-11-28 13:04:30 +0000
 
-- [marian](/docs/cmd/1.7.0/marian): for training NMT models and language models
-- [marian-decoder](/docs/cmd/1.7.0/marian-decoder): for CPU and GPU translation using
+- [marian]({% link docs/cmd/1.7.0/marian.md %}): for training NMT models and language models
+- [marian-decoder]({% link docs/cmd/1.7.0/marian-decoder.md %}): for CPU and GPU translation using
   NMT models trained with Marian, and specific models trained with Nematus
-- [marian-server](/docs/cmd/1.7.0/marian-server): a web-socket server providing
+- [marian-server]({% link docs/cmd/1.7.0/marian-server.md %}): a web-socket server providing
   translation service
-- [marian-scorer](/docs/cmd/1.7.0/marian-scorer): for rescoring parallel text files
+- [marian-scorer]({% link docs/cmd/1.7.0/marian-scorer.md %}): for rescoring parallel text files
   and n-best lists
-- [marian-vocab](/docs/cmd/1.7.0/marian-vocab): for creating a vocabulary from text
+- [marian-vocab]({% link docs/cmd/1.7.0/marian-vocab.md %}): for creating a vocabulary from text
   given on STDIN
-- [amun](/docs/cmd/1.7.0/amun): for CPU and GPU translation using specific models
+- [amun]({% link docs/cmd/amun.md %}): for CPU and GPU translation using specific models
   trained with Marian or Nematus

--- a/docs/cmd/index.md
+++ b/docs/cmd/index.md
@@ -15,10 +15,10 @@ its separate repository and is available from:
 [https://github.com/marian-nmt/amun](https://github.com/marian-nmt/amun)
 
 
-### Version 1.9.1
+### Version {{ site.data.marian.version }}
 
 Version:
-v1.9.1 95c65bb 2020-03-17 03:30:49 +0000
+{{ site.data.marian.version_full }}
 
 - [marian](/docs/cmd/marian): training NMT models and language models.
 - [marian-decoder](/docs/cmd/marian-decoder): CPU and GPU translation using NMT
@@ -49,4 +49,3 @@ v1.7.0 67124f8 2018-11-28 13:04:30 +0000
   given on STDIN
 - [amun](/docs/cmd/1.7.0/amun): for CPU and GPU translation using specific models
   trained with Marian or Nematus
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ latex: true
 ## Overview
 
 Version:
-v1.9.1 95c65bb 2020-03-17 03:30:49 +0000
+{{ site.data.marian.version_full }}
 
 Marian toolkit provides the following tools:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,19 +14,19 @@ Version:
 
 Marian toolkit provides the following tools:
 
-- [marian](/docs/cmd/marian): training NMT models and language models.
-- [marian-decoder](/docs/cmd/marian-decoder): CPU and GPU translation with NMT
+- [marian]({% link docs/cmd/marian.md %}): training NMT models and language models.
+- [marian-decoder]({% link docs/cmd/marian-decoder.md %}): CPU and GPU translation with NMT
   models trained with Marian.
-- [marian-server](/docs/cmd/marian-server): a web-socket server providing
+- [marian-server]({% link docs/cmd/marian-server.md %}): a web-socket server providing
   translation service.
-- [marian-scorer](/docs/cmd/marian-scorer): rescoring parallel text files and
+- [marian-scorer]({% link docs/cmd/marian-scorer.md %}): rescoring parallel text files and
   n-best lists.
-- [marian-vocab](/docs/cmd/marian-vocab): creating a vocabulary from text given
+- [marian-vocab]({% link docs/cmd/marian-vocab.md %}): creating a vocabulary from text given
   on STDIN.
-- [marian-conv](/docs/cmd/marian-conv): converting a model into a binary
+- [marian-conv]({% link docs/cmd/marian-conv.md %}): converting a model into a binary
   format.
 
-The [amun](/docs/cmd/amun) tool offering CPU and GPU translation with specific
+The [amun]({% link docs/cmd/amun.md %}) tool offering CPU and GPU translation with specific
 Marian and Nematus models, which used to be a part of Marian, has been moved to
 its separate repository and is available from:
 [https://github.com/marian-nmt/amun](https://github.com/marian-nmt/amun)
@@ -36,13 +36,13 @@ its separate repository and is available from:
 ### Command-line options
 
 Click on the tool name above for a list of command line options. See options
-for [previous releases](/docs/cmd).
+for [previous releases]({% link docs/cmd/index.md %}).
 
 
 
 ### Code documentation
 
-[The developer documentation for Marian](/docs/api/) is generated using Doxygen
+[The developer documentation for Marian]({{ 'docs/api/' | relative_url }}) is generated using Doxygen
 and Sphinx. It can be generated locally from the {% github_link marian-dev/doc/
 %} folder.
 
@@ -88,7 +88,7 @@ The complete list of compilation options in the form of CMake flags can be
 obtained by running `cmake -LH -N` or `cmake -LAH -N` from the `build`
 directory after running `cmake ..` first.
 
-For details on installation under Windows see [the documentation below](/docs/#compilation-on-windows).
+For details on installation under Windows see [the documentation below]({% link docs/index.md %}#compilation-on-windows ).
 
 
 


### PR DESCRIPTION
This PR refactors the CI to separate the workflow and scripts, to allow contributors to test locally.

- Move some website generation away from being defined in github action yaml to the Makefile.The Makefile uses the submodule as source for compilation, and extraction of version information and CLI output.
- Hardcoded version information has been replaced with a Jekyll datafile. 
- The CI better handles deployment in forks, and inspection via PRs by using baseurl more consistently.
- Markdown links in command help now use Jekyll tags to compute their relative url. The use of links provides a build time check of link target validity.
- Updates the compilation in the CI to explicitly install required gcc/g++ versions. 
- This PR removes the commit-and-deploy workflow. 
- Update the README detailing the automated workflow, and how to test locally. Closes: #34 .

The result of this PR can be seen at https://graemenail.github.io/marian-nmt.github.io, and its [associated action](https://github.com/graemenail/marian-nmt.github.io/actions/runs/1740171869).
