### PR TITLE
API documentation is always built on re-run jobs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -67,6 +67,12 @@ jobs:
               echo '::set-output name=changed::true';
             fi
 
+            # Always run on re-run jobs
+            if [ "${{ github.run_attempt }}" -gt "1" ]; then
+              echo '::set-output name=changed::true';
+            fi
+
+
   # Compile Marian to get CLI options
   cli:
     name: Build CLI documentation


### PR DESCRIPTION
There's an edge case where old API documentation is mistakenly recycled when the commit that updates the submodule results in a failed workflow. Following commits may repair the workflow, but as they (typically) don't touch the submodule, the API generation is skipped, and falls back to the inplace API docs.

This PR provides a workaround in that re-running a workflow forces building of the API documentation.
Alternatively, we can just disable the checks on submodule changes and always generate API.

What do you think @snukky ? 
