### PR TITLE
Add link to Developer API; small updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install: Gemfile
 update-gems: Gemfile
 	bundle update
 
-## Updte pages with command-line options
+## Update pages with command-line options
 update-cmds: $(CMDFILES)
 
 ## Update verion datafile
@@ -61,7 +61,6 @@ $(MARIAN):
 		&& cd marian-dev/build \
 		&& cmake .. -DCOMPILE_SERVER=ON \
 		&& make -j8
-
 
 # Clean
 clean:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The website is build with Jekyll - a static site generator.
 The content is created and updated on branch `jekyll`, then the static pages
 are generated with Jekyll and stored in the branch `master`.
 
-Please **do not update files directly in `master`**.
+:warning: Please **do not update files directly in `master`**. :warning:
 
 ## Automated build
 
@@ -20,7 +20,7 @@ This covers:
 The CLI and API document content is determined by the pinned version of the
 marian-dev submodule.
 
-The CLI documentation
+### The CLI documentation
 
 This pipeline is triggered by pushes on the source branch `jekyll`, and, on
 success, the resulting site is pushed to the GitHub pages branch (`master`).
@@ -31,7 +31,6 @@ pushed onto the source branch (message: `Update CLI options:`).
 This is necessary due to the renderedtimestamp of these files being
 determined from their last-commit date.
 -->
-
 For pull requests against the source branch, the resulting site is available as
 an artifact and should be reviewed before approval.
 

--- a/_data/cards.yml
+++ b/_data/cards.yml
@@ -23,8 +23,8 @@
   link: faq
   icon: fa-life-ring
   color: blue
-- title: Blog
-  intro: Blog post for when we feel creative
-  link: blog
-  icon: fa-pencil
+- title: Developer API
+  intro: Developer documentation and library API
+  link: docs/api
+  icon: fa-code-fork
   color: orange

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,14 +40,6 @@ for [previous releases]({% link docs/cmd/index.md %}).
 
 
 
-### Code documentation
-
-[The developer documentation for Marian]({{ 'docs/api/' | relative_url }}) is generated using Doxygen
-and Sphinx. It can be generated locally from the {% github_link marian-dev/doc/
-%} folder.
-
-
-
 ### Model types
 
 - `s2s`: An RNN-based encoder-decoder model with attention mechanism. The
@@ -67,6 +59,14 @@ and Sphinx. It can be generated locally from the {% github_link marian-dev/doc/
   Can be decoded with Amun as _nematus2_ model type.
 - `lm`: An RNN language model.
 - `lm-transformer`: An transformer-based language model.
+
+
+
+### Developer API
+
+[The developer documentation for Marian]({{ 'docs/api/' | relative_url }}) is
+generated using Doxygen and Sphinx. The newest version can be generated locally
+from the {% github_link marian-dev/doc/ %} folder.
 
 
 


### PR DESCRIPTION
Small updates to the website:
- Warning icons to "don't push to master" in README.
- Changing "code documentation" to "Developer API".
- Link to the Developer API on the home page.