### PR TITLE
Fix CLI markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,8 @@ $(MARIAN)/marian.sha:
 
 ## Build CLI markdown file
 docs/cmd/%.md: docs/cmd/_template.tmp $(MARIAN)/%.version $(MARIAN)/%.help
-	sed "s/<COMMAND>/$*/" $< > $@
-	echo "Version: " >> $@
-	cat $(MARIAN)/$*.version >> $@
-	echo "" >> $@
-	cat $(MARIAN)/$*.help | bash _scripts/help2markdown.sh | python _scripts/wrap_help.py >> $@
+	python _scripts/generate_cli_md.py $* $(MARIAN)/$*.version $(MARIAN)/$*.help \
+	| python _scripts/wrap_help.py > $@
 
 ## Compile Marian
 $(MARIAN):

--- a/_scripts/generate_cli_md.py
+++ b/_scripts/generate_cli_md.py
@@ -14,6 +14,7 @@ It enables the follow tags:
 
 from collections import defaultdict
 import argparse
+import re
 import os
 import sys
 
@@ -94,9 +95,12 @@ def parse_help(help_file):
             # Skip empty
             continue
 
+        if is_block(mode):
+            line = re.sub(r"^\s{2}", "", line)
+
         # Append line to mode
         if mode >= 0:
-            output[modes[mode]].append(line.strip())
+            output[modes[mode]].append(line.rstrip())
 
     # Tidy up blocks
     if is_block(mode):

--- a/_scripts/generate_cli_md.py
+++ b/_scripts/generate_cli_md.py
@@ -75,6 +75,7 @@ def parse_help(help_file):
         # Set usage mode
         if line.startswith("Usage:"):
             mode = 1
+            line = line.replace("Usage: ","")
 
         # Set options mode
         if line.strip().endswith("options:"):

--- a/_scripts/generate_cli_md.py
+++ b/_scripts/generate_cli_md.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+"""Marian CLI to markdown converter
+
+This script populates a markdown template to document Marian commands.
+
+It enables the follow tags:
+  * command
+  * description
+  * version
+  * options
+  * examples
+"""
+
+from collections import defaultdict
+import argparse
+import os
+import sys
+
+
+class IgnoreMissing(dict):
+    """Dict that returns an empty string for missing keys"""
+
+    def __missing__(self, key):
+        return ""
+
+
+# Define markdown insertions
+blockheading = "### "
+codeblock = "```"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate command documentation")
+
+    parser.add_argument(
+        "name", type=str, help="Name of marian comman (e.g. marian-decoder)"
+    )
+    parser.add_argument(
+        "versionfile",
+        type=argparse.FileType("r"),
+        help="File containing the output of '--version' (e.g. marian-decoder --version)",
+    )
+    parser.add_argument(
+        "helpfile",
+        type=argparse.FileType("r"),
+        help="File containing the output of '--help' (e.g. marian-decoder --help)",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="OUTPUT.md",
+        type=argparse.FileType("w"),
+        default=sys.stdout,
+        help="Location to emit markdown (Default: STDOUT)",
+    )
+
+    return parser.parse_args()
+
+
+def parse_version(version_file):
+    output = "".join(version_file.readlines()).strip()
+    return output
+
+
+def parse_help(help_file):
+    output = defaultdict(list)
+    modes = ["description", "usage", "options", "examples"]
+    mode = 0  # default description mode
+
+    is_block = lambda m: m == 2 or m == 3
+    for line in help_file:
+        # Set usage mode
+        if line.startswith("Usage:"):
+            mode = 1
+
+        # Set options mode
+        if line.strip().endswith("options:"):
+            mode = 2
+            line = f"{blockheading}{line.strip()[:-1]}\n{codeblock}"
+
+        # Set example mode
+        if line.startswith("Examples:"):
+            mode = 3
+            line = f"{blockheading}{line.strip()[:-1]}\n{codeblock}"
+
+        # Empty line
+        if not line.strip():
+            # End block modes
+            if is_block(mode):
+                output[modes[mode]].append(codeblock)
+                mode = -1
+            # Skip empty
+            continue
+
+        # Append line to mode
+        if mode >= 0:
+            output[modes[mode]].append(line.strip())
+
+    # Tidy up blocks
+    if is_block(mode):
+        output[modes[mode]].append(codeblock)
+
+    # Join lines and return
+    return {k: "\n".join(v) for k, v in output.items()}
+
+
+def main():
+    basepath = os.path.dirname(__file__)
+    relative_template = "../docs/cmd/_template.tmp"
+
+    args = parse_args()
+
+    version = parse_version(args.versionfile)
+    help = parse_help(args.helpfile)
+
+    with open(os.path.join(basepath, relative_template), "r") as tpl:
+        template = tpl.read()
+        output = template.format_map(
+            IgnoreMissing(command=args.name, version=version, **help)
+        )
+        print(output, file=args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/_scripts/wrap_help.py
+++ b/_scripts/wrap_help.py
@@ -10,12 +10,18 @@ COLUMN_WIDTH = 40
 LINE_WIDTH = 100
 DEBUG = False
 
+codeblock="```"
+in_block = False
 
 for l, line in enumerate(sys.stdin):
     text = line.rstrip()
-    if len(text) <= LINE_WIDTH:
+
+    if text == codeblock:
+        in_block = not in_block
         print(text)
-    else:
+        continue
+
+    if in_block and len(text) > LINE_WIDTH:
         if DEBUG:
             print('>>> line {} has length {}'.format(l, len(text)))
         space_left = LINE_WIDTH
@@ -42,4 +48,5 @@ for l, line in enumerate(sys.stdin):
             if i > 0:
                 print(" " * (COLUMN_WIDTH - 2), end='')
             print(text[s:e])
-
+    else:
+        print(text)

--- a/docs/cmd/_template.tmp
+++ b/docs/cmd/_template.tmp
@@ -10,6 +10,8 @@ icon: fa-file-code-o
 
 Version: {version}
 
+Usage: `{usage}`
+
 {options}
 
 {examples}

--- a/docs/cmd/_template.tmp
+++ b/docs/cmd/_template.tmp
@@ -1,9 +1,15 @@
 ---
 layout: docs
-title: Command-line options for <COMMAND>
-permalink: /docs/cmd/<COMMAND>/
+title: Command-line options for {command}
+permalink: /docs/cmd/{command}/
 icon: fa-file-code-o
 ---
 
-## <COMMAND>
+## {command}
+{description}
 
+Version: {version}
+
+{options}
+
+{examples}


### PR DESCRIPTION
This PR updates the generation of the CLI markdown documents.

  - Replaces the bash script with a python script.
  - Only performs line wrapping inside codeblocks
  - Adds command-description to template

Fixes #42.