### PR TITLE
Add dependabot for git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  # Maintain dependencies for Git Submodules
+  - package-ecosystem: "gitsubmodule"
+    target-branch: "jekyll"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We can automate the updating of the marian-dev submodule with dependabot.

However, this requires setting `jekyll` as the default branch in the repository. I tested this on my fork, and it was fine.
We can add a branch protection on master to prevent force-pushes/delection etc.

These actions can be taken after merging. 
While `jekyll` is a non-default branch the UI shows a warning when viewing the dependabot file that it won't be considered.
